### PR TITLE
Secure task status updates

### DIFF
--- a/project.php
+++ b/project.php
@@ -163,12 +163,24 @@ unset($_SESSION['success'], $_SESSION['error']);
                                         <!-- Quick status change buttons -->
                                         <div class="mt-2">
                                             <div class="btn-group btn-group-sm" role="group">
-                                                <a href="update_task_status.php?id=<?php echo $task['task_id']; ?>&status=To Do" 
-                                                   class="btn btn-outline-info <?php echo $task['status'] == 'To Do' ? 'active' : ''; ?>">To Do</a>
-                                                <a href="update_task_status.php?id=<?php echo $task['task_id']; ?>&status=In Progress" 
-                                                   class="btn btn-outline-warning <?php echo $task['status'] == 'In Progress' ? 'active' : ''; ?>">In Progress</a>
-                                                <a href="update_task_status.php?id=<?php echo $task['task_id']; ?>&status=Completed" 
-                                                   class="btn btn-outline-success <?php echo $task['status'] == 'Completed' ? 'active' : ''; ?>">Completed</a>
+                                                <form action="update_task_status.php" method="post" class="d-inline">
+                                                    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(generate_csrf_token()); ?>">
+                                                    <input type="hidden" name="id" value="<?php echo $task['task_id']; ?>">
+                                                    <input type="hidden" name="status" value="To Do">
+                                                    <button type="submit" class="btn btn-outline-info <?php echo $task['status'] == 'To Do' ? 'active' : ''; ?>">To Do</button>
+                                                </form>
+                                                <form action="update_task_status.php" method="post" class="d-inline">
+                                                    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(generate_csrf_token()); ?>">
+                                                    <input type="hidden" name="id" value="<?php echo $task['task_id']; ?>">
+                                                    <input type="hidden" name="status" value="In Progress">
+                                                    <button type="submit" class="btn btn-outline-warning <?php echo $task['status'] == 'In Progress' ? 'active' : ''; ?>">In Progress</button>
+                                                </form>
+                                                <form action="update_task_status.php" method="post" class="d-inline">
+                                                    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(generate_csrf_token()); ?>">
+                                                    <input type="hidden" name="id" value="<?php echo $task['task_id']; ?>">
+                                                    <input type="hidden" name="status" value="Completed">
+                                                    <button type="submit" class="btn btn-outline-success <?php echo $task['status'] == 'Completed' ? 'active' : ''; ?>">Completed</button>
+                                                </form>
                                             </div>
                                         </div>
                                     </div>

--- a/task.php
+++ b/task.php
@@ -200,19 +200,34 @@ unset($_SESSION['success'], $_SESSION['error']);
                                 <div class="card-body">
                                     <div class="d-grid gap-2">
                                         <?php if ($task['status'] != 'In Progress'): ?>
-                                            <a href="update_task_status.php?id=<?php echo $task_id; ?>&status=In Progress" class="btn btn-warning">
-                                                <i class="bi bi-play-fill"></i> Mark In Progress
-                                            </a>
+                                            <form action="update_task_status.php" method="post" class="d-grid">
+                                                <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(generate_csrf_token()); ?>">
+                                                <input type="hidden" name="id" value="<?php echo $task_id; ?>">
+                                                <input type="hidden" name="status" value="In Progress">
+                                                <button type="submit" class="btn btn-warning">
+                                                    <i class="bi bi-play-fill"></i> Mark In Progress
+                                                </button>
+                                            </form>
                                         <?php endif; ?>
-                                        
+
                                         <?php if ($task['status'] != 'Completed'): ?>
-                                            <a href="update_task_status.php?id=<?php echo $task_id; ?>&status=Completed" class="btn btn-success">
-                                                <i class="bi bi-check-lg"></i> Mark Completed
-                                            </a>
+                                            <form action="update_task_status.php" method="post" class="d-grid">
+                                                <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(generate_csrf_token()); ?>">
+                                                <input type="hidden" name="id" value="<?php echo $task_id; ?>">
+                                                <input type="hidden" name="status" value="Completed">
+                                                <button type="submit" class="btn btn-success">
+                                                    <i class="bi bi-check-lg"></i> Mark Completed
+                                                </button>
+                                            </form>
                                         <?php else: ?>
-                                            <a href="update_task_status.php?id=<?php echo $task_id; ?>&status=To Do" class="btn btn-info">
-                                                <i class="bi bi-arrow-repeat"></i> Reopen Task
-                                            </a>
+                                            <form action="update_task_status.php" method="post" class="d-grid">
+                                                <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(generate_csrf_token()); ?>">
+                                                <input type="hidden" name="id" value="<?php echo $task_id; ?>">
+                                                <input type="hidden" name="status" value="To Do">
+                                                <button type="submit" class="btn btn-info">
+                                                    <i class="bi bi-arrow-repeat"></i> Reopen Task
+                                                </button>
+                                            </form>
                                         <?php endif; ?>
                                         
                                         <button type="button" class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#deleteTaskModal">
@@ -348,6 +363,9 @@ unset($_SESSION['success'], $_SESSION['error']);
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <!-- GSAP for smooth animations -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
+    <script>
+        window.CSRF_TOKEN = "<?php echo htmlspecialchars(generate_csrf_token()); ?>";
+    </script>
     <script>
     document.addEventListener('DOMContentLoaded', function() {
         // Animate task card on load

--- a/tasks.php
+++ b/tasks.php
@@ -141,12 +141,24 @@ $projects = $stmt->fetchAll();
                                         
                                         <div class="d-flex justify-content-between">
                                             <div class="btn-group btn-group-sm" role="group">
-                                                <a href="update_task_status.php?id=<?php echo $task['task_id']; ?>&status=To Do" 
-                                                   class="btn btn-outline-info <?php echo $task['status'] == 'To Do' ? 'active' : ''; ?>">To Do</a>
-                                                <a href="update_task_status.php?id=<?php echo $task['task_id']; ?>&status=In Progress" 
-                                                   class="btn btn-outline-warning <?php echo $task['status'] == 'In Progress' ? 'active' : ''; ?>">In Progress</a>
-                                                <a href="update_task_status.php?id=<?php echo $task['task_id']; ?>&status=Completed" 
-                                                   class="btn btn-outline-success <?php echo $task['status'] == 'Completed' ? 'active' : ''; ?>">Completed</a>
+                                                <form action="update_task_status.php" method="post" class="d-inline">
+                                                    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(generate_csrf_token()); ?>">
+                                                    <input type="hidden" name="id" value="<?php echo $task['task_id']; ?>">
+                                                    <input type="hidden" name="status" value="To Do">
+                                                    <button type="submit" class="btn btn-outline-info <?php echo $task['status'] == 'To Do' ? 'active' : ''; ?>">To Do</button>
+                                                </form>
+                                                <form action="update_task_status.php" method="post" class="d-inline">
+                                                    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(generate_csrf_token()); ?>">
+                                                    <input type="hidden" name="id" value="<?php echo $task['task_id']; ?>">
+                                                    <input type="hidden" name="status" value="In Progress">
+                                                    <button type="submit" class="btn btn-outline-warning <?php echo $task['status'] == 'In Progress' ? 'active' : ''; ?>">In Progress</button>
+                                                </form>
+                                                <form action="update_task_status.php" method="post" class="d-inline">
+                                                    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(generate_csrf_token()); ?>">
+                                                    <input type="hidden" name="id" value="<?php echo $task['task_id']; ?>">
+                                                    <input type="hidden" name="status" value="Completed">
+                                                    <button type="submit" class="btn btn-outline-success <?php echo $task['status'] == 'Completed' ? 'active' : ''; ?>">Completed</button>
+                                                </form>
                                             </div>
                                         </div>
                                         

--- a/update_task_status.php
+++ b/update_task_status.php
@@ -1,6 +1,9 @@
 <?php
 session_start();
+require_once 'functions.php';
 require_once 'config/db_connect.php';
+
+require_login();
 
 // Redirect if not logged in
 if (!isset($_SESSION['user_id'])) {
@@ -8,15 +11,29 @@ if (!isset($_SESSION['user_id'])) {
     exit;
 }
 
+// Ensure POST request and validate CSRF token
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    $_SESSION['error'] = "Invalid request method";
+    header('Location: projects.php');
+    exit;
+}
+
+if (!validate_csrf_token($_POST['csrf_token'] ?? '')) {
+    $_SESSION['error'] = 'Invalid CSRF token.';
+    log_error('CSRF token mismatch on update_task_status');
+    header('Location: projects.php');
+    exit;
+}
+
 // Check if required parameters are provided
-if (!isset($_GET['id']) || !is_numeric($_GET['id']) || !isset($_GET['status'])) {
+if (!isset($_POST['id']) || !is_numeric($_POST['id']) || !isset($_POST['status'])) {
     $_SESSION['error'] = "Invalid request";
     header('Location: projects.php');
     exit;
 }
 
-$task_id = $_GET['id'];
-$status = $_GET['status'];
+$task_id = $_POST['id'];
+$status = $_POST['status'];
 
 // Validate status
 $valid_statuses = ['To Do', 'In Progress', 'Completed'];


### PR DESCRIPTION
## Summary
- require POST requests for `update_task_status.php`
- validate CSRF tokens in `update_task_status.php`
- add CSRF token generation and POST forms for status buttons in task views
- ensure CSRF token available for modals
- add trailing newlines to updated files

## Testing
- `php -l update_task_status.php`
- `php -l tasks.php`
- `php -l project.php`
- `php -l task.php`


------
https://chatgpt.com/codex/tasks/task_e_687fa0d99e908330a42e844dfcd7d87a