### PR TITLE
Implement secure project deletion

### DIFF
--- a/delete_project.php
+++ b/delete_project.php
@@ -1,0 +1,61 @@
+<?php
+session_start();
+require_once 'functions.php';
+require_once 'config/db_connect.php';
+
+require_login();
+
+// Ensure user is logged in
+if (!isset($_SESSION['user_id'])) {
+    header('Location: login.php');
+    exit;
+}
+
+// Validate project ID
+if (!isset($_GET['id']) || !is_numeric($_GET['id'])) {
+    $_SESSION['error'] = "Invalid project ID";
+    header('Location: projects.php');
+    exit;
+}
+
+// Validate CSRF token
+if (!validate_csrf_token($_GET['csrf_token'] ?? '')) {
+    $_SESSION['error'] = 'Invalid CSRF token.';
+    log_error('CSRF token mismatch on delete_project');
+    header('Location: projects.php');
+    exit;
+}
+
+$project_id = $_GET['id'];
+
+try {
+    // Verify project ownership
+    $stmt = $pdo->prepare("SELECT user_id FROM projects WHERE project_id = ?");
+    $stmt->execute([$project_id]);
+    $project = $stmt->fetch();
+
+    if (!$project || $project['user_id'] != $_SESSION['user_id']) {
+        $_SESSION['error'] = "You don't have permission to delete this project";
+        header('Location: projects.php');
+        exit;
+    }
+
+    // Delete project (tasks will cascade via FK)
+    $stmt = $pdo->prepare("DELETE FROM projects WHERE project_id = ?");
+    $result = $stmt->execute([$project_id]);
+
+    if ($result) {
+        $_SESSION['success'] = "Project deleted successfully";
+    } else {
+        $_SESSION['error'] = "Failed to delete project";
+    }
+
+    header('Location: projects.php');
+    exit;
+
+} catch (PDOException $e) {
+    $_SESSION['error'] = "Database error: " . $e->getMessage();
+    log_error('Delete project error: ' . $e->getMessage());
+    header('Location: projects.php');
+    exit;
+}

--- a/projects.php
+++ b/projects.php
@@ -410,7 +410,11 @@ $tasks = $stmt->fetchAll();
                 
                 // Update the modal's content
                 document.getElementById('deleteProjectName').textContent = projectName;
-                document.getElementById('confirmDeleteBtn').href = 'delete_project.php?id=' + projectId;
+                let href = 'delete_project.php?id=' + projectId;
+                if (window.CSRF_TOKEN) {
+                    href += '&csrf_token=' + encodeURIComponent(window.CSRF_TOKEN);
+                }
+                document.getElementById('confirmDeleteBtn').href = href;
             });
         }
 


### PR DESCRIPTION
## Summary
- add `delete_project.php` to validate project ownership and CSRF token before deleting
- cascade deletion to associated tasks via FK
- enhance Delete Project modal to include CSRF token when constructing delete URL

## Testing
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687fa137c5bc83309251db56a4459f06